### PR TITLE
[BUG] 修复在分析部分类的时候发生空指针异常的问题

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
@@ -45,7 +45,8 @@ public class SpringMethodAdapter extends MethodVisitor {
         if (descriptor.equals(SpringConstant.RequestMappingAnno) ||
                 descriptor.equals(SpringConstant.GetMappingAnno) ||
                 descriptor.equals(SpringConstant.PostMappingAnno)) {
-            currentMapping = new SpringMapping();
+            if (currentMapping == null)
+                currentMapping = new SpringMapping();
             currentMapping.setMethodName(new MethodReference.Handle(
                     new ClassReference.Handle(this.owner), this.name, this.desc));
             currentMapping.setController(controller);

--- a/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
@@ -55,6 +55,8 @@ public class SpringMethodAdapter extends MethodVisitor {
             av = pathAnnoAdapter;
         }
         if (descriptor.equals(SpringConstant.ResponseBodyAnno)) {
+            if (currentMapping == null)
+                currentMapping = new SpringMapping();
             currentMapping.setRest(true);
         }
         return av;


### PR DESCRIPTION
修复在分析部分类的时候发生空指针异常的问题

例如在分析`io.choerodon.swagger.controller.CustomController`类时，`getDocumentation`方法的`ResponseBody`注解先于`GetMapping`注解声明，将导致空指针异常。