### PR TITLE
[FEAT] EL 表达式支持 excludeAnno，用于过滤注解。

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/el/MethodEL.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/el/MethodEL.java
@@ -16,6 +16,7 @@ public class MethodEL {
     private Integer paramsNum;
     private Boolean isStatic;
     private String methodAnno;
+    private String excludedMethodAnno;
     private String classAnno;
     private String field;
 
@@ -120,6 +121,14 @@ public class MethodEL {
         this.methodAnno = methodAnno;
     }
 
+    public String getExcludedMethodAnno() {
+        return excludedMethodAnno;
+    }
+
+    public void setExcludedMethodAnno(String excludedMethodAnno) {
+        this.excludedMethodAnno = excludedMethodAnno;
+    }
+
     public String getClassAnno() {
         return classAnno;
     }
@@ -196,6 +205,11 @@ public class MethodEL {
 
     public MethodEL hasAnno(String s) {
         this.methodAnno = s;
+        return this;
+    }
+
+    public MethodEL excludeAnno(String s) {
+        this.excludedMethodAnno = s;
         return this;
     }
 

--- a/src/main/java/me/n1ar4/jar/analyzer/el/MethodELProcessor.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/el/MethodELProcessor.java
@@ -33,6 +33,7 @@ public class MethodELProcessor {
         Map<Integer, String> paramMap = condition.getParamTypes();
 
         String methodAnno = condition.getMethodAnno();
+        String excludedMethodAnno = condition.getExcludedMethodAnno();
         String classAnno = condition.getClassAnno();
 
         String isSubOf = condition.getIsSubClassOf();
@@ -108,6 +109,8 @@ public class MethodELProcessor {
                 }
             }
         }
+
+        boolean isExcludedMethod = isExcludedMethodAnno(excludedMethodAnno);
 
         if (start != null && !start.isEmpty()) {
             sw = mr.getName().startsWith(start);
@@ -187,8 +190,25 @@ public class MethodELProcessor {
                 break;
             }
         }
-        if (aa && ab && ac && ad && ae && af && ag && ah && ai && sb && sp && sw && ew) {
+        if (aa && ab && ac && ad && ae && af && ag && ah && ai && sb && sp && sw && ew && !isExcludedMethod) {
             searchList.add(new ResObj(mr.getHandle(), ch.getName()));
         }
+    }
+
+    private boolean isExcludedMethodAnno(String excludedMethodAnno) {
+        if (mr.getAnnotations() == null || mr.getAnnotations().isEmpty()) {
+            return false;
+        }
+        if (excludedMethodAnno == null || excludedMethodAnno.isEmpty()) {
+            return false;
+        }
+        boolean isExcludedMethodAnno = false;
+        for (String annotation : mr.getAnnotations()) {
+            if (annotation.contains(excludedMethodAnno)) {
+                isExcludedMethodAnno = true;
+                break;
+            }
+        }
+        return isExcludedMethodAnno;
     }
 }

--- a/src/main/java/me/n1ar4/jar/analyzer/engine/CoreHelper.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/engine/CoreHelper.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("all")
@@ -569,19 +570,33 @@ public class CoreHelper {
                     "PLEASE BUILD DATABASE FIRST");
             return;
         }
-        DefaultListModel<MethodResult> methodsList = new DefaultListModel<>();
-        for (ResObj result : methods) {
-            MethodResult mr = new MethodResult();
-            mr.setClassName(result.getClassName());
-            mr.setMethodName(result.getMethod().getName());
-            mr.setMethodDesc(result.getMethod().getDesc());
-            methodsList.addElement(mr);
-        }
-        if (methodsList.isEmpty() || methodsList.size() == 0) {
+        if (methods.isEmpty()) {
             JOptionPane.showMessageDialog(MainForm.getInstance().getMasterPanel(),
                     "result is null");
             return;
         }
+
+        List<MethodResult> methodResultList = methods.stream().map(new Function<ResObj, MethodResult>() {
+            @Override
+            public MethodResult apply(ResObj resObj) {
+                MethodResult methodResult = new MethodResult();
+                methodResult.setClassName(resObj.getClassName());
+                methodResult.setMethodName(resObj.getMethod().getName());
+                methodResult.setMethodDesc(resObj.getMethod().getDesc());
+                return methodResult;
+            }
+        }).collect(Collectors.toList());
+
+        if (MenuUtil.sortedByMethod()) {
+            methodResultList.sort(Comparator.comparing(MethodResult::getMethodName));
+        }
+        if (MenuUtil.sortedByClass()) {
+            methodResultList.sort(Comparator.comparing(MethodResult::getClassName));
+        }
+
+        DefaultListModel<MethodResult> methodsList = new DefaultListModel<>();
+        methodResultList.forEach(methodsList::addElement);
+
         MainForm.getInstance().getSearchList().setModel(methodsList);
         MainForm.getInstance().getSearchList().repaint();
         MainForm.getInstance().getSearchList().revalidate();


### PR DESCRIPTION
在 java 代码审计时，有时候需要搜索 Controller 里缺少某个注解的接口，例如 @Auth 之类的，检查这个接口是否有越权问题。
使用方式，在 EL 表达式输入框中输入：
<img width="491" alt="截屏2024-08-20 下午6 19 03" src="https://github.com/user-attachments/assets/ccf54907-5d46-42a6-8014-b35d04ec6d69">

这个merge request 只支持排除单个注解，因为感觉未必有排除多个注解的需求。同时原有代码的 hasAnno 也只支持单个注解，所以就暂时这么设计了。