### PR TITLE
[FEAT] EL 表达式搜索结果根据行号排序

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/core/DatabaseManager.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/DatabaseManager.java
@@ -191,6 +191,7 @@ public class DatabaseManager {
             methodEntity.setClassName(reference.getClassReference().getName());
             methodEntity.setStatic(reference.isStatic());
             methodEntity.setAccess(reference.getAccess());
+            methodEntity.setLineNumber(reference.getLineNumber());
             mList.add(methodEntity);
             for (String anno : reference.getAnnotations()) {
                 AnnoEntity annoEntity = new AnnoEntity();

--- a/src/main/java/me/n1ar4/jar/analyzer/core/MethodReference.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/MethodReference.java
@@ -15,13 +15,14 @@ public class MethodReference {
     public MethodReference(ClassReference.Handle classReference,
                            String name, String desc, boolean isStatic,
                            Set<String> annotations,
-                           int access) {
+                           int access, int lineNumber) {
         this.classReference = classReference;
         this.name = name;
         this.desc = desc;
         this.isStatic = isStatic;
         this.annotations = annotations;
         this.access = access;
+        this.lineNumber = lineNumber;
     }
 
     public int getAccess() {

--- a/src/main/java/me/n1ar4/jar/analyzer/core/MethodReference.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/MethodReference.java
@@ -10,6 +10,7 @@ public class MethodReference {
     private final String desc;
     private final int access;
     private final boolean isStatic;
+    private int lineNumber = -1;
 
     public MethodReference(ClassReference.Handle classReference,
                            String name, String desc, boolean isStatic,
@@ -113,5 +114,13 @@ public class MethodReference {
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (desc != null ? desc.hashCode() : 0);
         return result;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
     }
 }

--- a/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryClassVisitor.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryClassVisitor.java
@@ -67,7 +67,7 @@ public class DiscoveryClassVisitor extends ClassVisitor {
                                      String signature, String[] exceptions) {
         boolean isStatic = (access & Opcodes.ACC_STATIC) != 0;
         Set<String> mAnno = new HashSet<>();
-        MethodReference methodReference = new MethodReference(classHandle, name, desc, isStatic, mAnno, access);
+        MethodReference methodReference = new MethodReference(classHandle, name, desc, isStatic, mAnno, access, -1);
         discoveredMethods.add(methodReference);
         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
         return new DiscoveryMethodAdapter(Const.ASMVersion, mv, mAnno, methodReference);

--- a/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryClassVisitor.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryClassVisitor.java
@@ -67,14 +67,10 @@ public class DiscoveryClassVisitor extends ClassVisitor {
                                      String signature, String[] exceptions) {
         boolean isStatic = (access & Opcodes.ACC_STATIC) != 0;
         Set<String> mAnno = new HashSet<>();
-        discoveredMethods.add(new MethodReference(
-                classHandle,
-                name,
-                desc,
-                isStatic,
-                mAnno, access));
+        MethodReference methodReference = new MethodReference(classHandle, name, desc, isStatic, mAnno, access);
+        discoveredMethods.add(methodReference);
         MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-        return new DiscoveryMethodAdapter(Const.ASMVersion, mv, mAnno);
+        return new DiscoveryMethodAdapter(Const.ASMVersion, mv, mAnno, methodReference);
     }
 
     @Override

--- a/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryMethodAdapter.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/asm/DiscoveryMethodAdapter.java
@@ -1,6 +1,8 @@
 package me.n1ar4.jar.analyzer.core.asm;
 
+import me.n1ar4.jar.analyzer.core.MethodReference;
 import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 import java.util.Set;
@@ -9,10 +11,13 @@ public class DiscoveryMethodAdapter extends MethodVisitor {
 
     private final Set<String> anno;
 
+    private final MethodReference methodReference;
+
     protected DiscoveryMethodAdapter(int api, MethodVisitor methodVisitor,
-                                     Set<String> anno) {
+                                     Set<String> anno, MethodReference methodReference) {
         super(api, methodVisitor);
         this.anno = anno;
+        this.methodReference = methodReference;
     }
 
     @Override
@@ -25,5 +30,14 @@ public class DiscoveryMethodAdapter extends MethodVisitor {
     public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
         anno.add(descriptor);
         return super.visitParameterAnnotation(parameter, descriptor, visible);
+    }
+
+    @Override
+    public void visitLineNumber(int line, Label start) {
+        int lineNumber = methodReference.getLineNumber();
+        if (lineNumber == -1) {
+            this.methodReference.setLineNumber(line);
+        }
+        super.visitLineNumber(line, start);
     }
 }

--- a/src/main/java/me/n1ar4/jar/analyzer/el/MethodELProcessor.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/el/MethodELProcessor.java
@@ -191,7 +191,7 @@ public class MethodELProcessor {
             }
         }
         if (aa && ab && ac && ad && ae && af && ag && ah && ai && sb && sp && sw && ew && !isExcludedMethod) {
-            searchList.add(new ResObj(mr.getHandle(), ch.getName()));
+            searchList.add(new ResObj(mr.getHandle(), ch.getName(), mr.getLineNumber()));
         }
     }
 

--- a/src/main/java/me/n1ar4/jar/analyzer/el/ResObj.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/el/ResObj.java
@@ -6,10 +6,12 @@ import org.objectweb.asm.Type;
 public class ResObj {
     private final String className;
     private final MethodReference.Handle method;
+    private final int lineNumber;
 
-    public ResObj(MethodReference.Handle m, String className) {
+    public ResObj(MethodReference.Handle m, String className, int lineNumber) {
         this.className = className;
         this.method = m;
+        this.lineNumber = lineNumber;
     }
 
     public String getClassName() {
@@ -23,6 +25,10 @@ public class ResObj {
     private int getNumFromDesc() {
         Type methodType = Type.getMethodType(this.method.getDesc());
         return methodType.getArgumentTypes().length;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
     }
 
     @Override

--- a/src/main/java/me/n1ar4/jar/analyzer/engine/CoreEngine.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/engine/CoreEngine.java
@@ -313,7 +313,7 @@ public class CoreEngine {
             MethodReference mr = new MethodReference(mh.getClassReference(),
                     mh.getName(), mh.getDesc(),
                     result.getIsStaticInt() == 1,
-                    new HashSet<>(ma), result.getAccessInt());
+                    new HashSet<>(ma), result.getAccessInt(), result.getLineNumber());
             list.add(mr);
         }
         session.close();

--- a/src/main/java/me/n1ar4/jar/analyzer/engine/CoreHelper.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/engine/CoreHelper.java
@@ -1,5 +1,6 @@
 package me.n1ar4.jar.analyzer.engine;
 
+import me.n1ar4.jar.analyzer.core.MethodReference;
 import me.n1ar4.jar.analyzer.el.ResObj;
 import me.n1ar4.jar.analyzer.entity.ClassResult;
 import me.n1ar4.jar.analyzer.entity.MethodResult;
@@ -11,10 +12,7 @@ import me.n1ar4.jar.analyzer.gui.util.MenuUtil;
 import me.n1ar4.jar.analyzer.utils.StringUtil;
 
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -579,10 +577,12 @@ public class CoreHelper {
         List<MethodResult> methodResultList = methods.stream().map(new Function<ResObj, MethodResult>() {
             @Override
             public MethodResult apply(ResObj resObj) {
+                MethodReference.Handle methodHandler = resObj.getMethod();
                 MethodResult methodResult = new MethodResult();
                 methodResult.setClassName(resObj.getClassName());
-                methodResult.setMethodName(resObj.getMethod().getName());
-                methodResult.setMethodDesc(resObj.getMethod().getDesc());
+                methodResult.setMethodName(methodHandler.getName());
+                methodResult.setMethodDesc(methodHandler.getDesc());
+                methodResult.setLineNumber(resObj.getLineNumber());
                 return methodResult;
             }
         }).collect(Collectors.toList());
@@ -591,7 +591,8 @@ public class CoreHelper {
             methodResultList.sort(Comparator.comparing(MethodResult::getMethodName));
         }
         if (MenuUtil.sortedByClass()) {
-            methodResultList.sort(Comparator.comparing(MethodResult::getClassName));
+            Collections.sort(methodResultList, Comparator.comparing(MethodResult::getClassName)
+                    .thenComparing(MethodResult::getLineNumber));
         }
 
         DefaultListModel<MethodResult> methodsList = new DefaultListModel<>();

--- a/src/main/java/me/n1ar4/jar/analyzer/entity/MethodEntity.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/entity/MethodEntity.java
@@ -7,6 +7,7 @@ public class MethodEntity {
     private boolean isStatic;
     private String className;
     private int access;
+    private int lineNumber;
 
     public int getAccess() {
         return access;
@@ -54,6 +55,14 @@ public class MethodEntity {
 
     public void setClassName(String className) {
         this.className = className;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
     }
 
     @Override

--- a/src/main/java/me/n1ar4/jar/analyzer/entity/MethodResult.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/entity/MethodResult.java
@@ -18,6 +18,8 @@ public class MethodResult {
     @JSONField(serialize = false)
     private String path;
 
+    private int lineNumber;
+
     public String getPath() {
         this.path = this.path.trim();
         if (this.path.isEmpty()) {
@@ -87,6 +89,14 @@ public class MethodResult {
 
     public void setAccessInt(int accessInt) {
         this.accessInt = accessInt;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
     }
 
     @Override

--- a/src/main/resources/mappers/InitMapper.xml
+++ b/src/main/resources/mappers/InitMapper.xml
@@ -51,7 +51,8 @@
             method_desc TEXT NOT NULL,
             is_static INTEGER NOT NULL,
             class_name TEXT NOT NULL,
-            access INTEGER NOT NULL
+            access INTEGER NOT NULL,
+            line_number INTEGER NOT NULL
         );
     </update>
     <update id="createAnnoTable">

--- a/src/main/resources/mappers/MethodMapper.xml
+++ b/src/main/resources/mappers/MethodMapper.xml
@@ -19,23 +19,23 @@
         </foreach>
     </insert>
     <select id="selectMethodsByClassName" resultMap="methodMap">
-        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access
+        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access, m.line_number
         FROM method_table m
                  INNER JOIN class_file_table cf ON
             substr(cf.class_name, 1, length(cf.class_name) - 6) = m.class_name
         WHERE m.class_name = #{className}
     </select>
     <select id="selectMethodsByClassNameNoJar" resultMap="methodMap">
-        SELECT DISTINCT m.method_name, m.class_name, m.method_desc, m.is_static, m.access
+        SELECT DISTINCT m.method_name, m.class_name, m.method_desc, m.is_static, m.access, m.line_number
         FROM method_table m
         WHERE m.class_name = #{className}
     </select>
     <select id="selectAllMethods" resultMap="methodMap">
-        SELECT m.method_name, m.class_name, m.method_desc, m.is_static, m.access
+        SELECT m.method_name, m.class_name, m.method_desc, m.is_static, m.access, m.line_number
         FROM method_table m
     </select>
     <select id="selectMethods" resultMap="methodMap">
-        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access
+        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access, m.line_number
         FROM method_table m
         INNER JOIN class_file_table cf ON
         substr(cf.class_name, 1, length(cf.class_name) - 6) = m.class_name
@@ -52,7 +52,7 @@
         </where>
     </select>
     <select id="selectMethodsLike" resultMap="methodMap">
-        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access
+        SELECT DISTINCT cf.jar_name, m.method_name, m.class_name, m.method_desc, m.is_static, m.access, m.line_number
         FROM method_table m
         INNER JOIN class_file_table cf ON
         substr(cf.class_name, 1, length(cf.class_name) - 6) = m.class_name

--- a/src/main/resources/mappers/MethodMapper.xml
+++ b/src/main/resources/mappers/MethodMapper.xml
@@ -8,13 +8,14 @@
         <result column="method_desc" property="methodDesc"/>
         <result column="is_static" property="isStaticInt"/>
         <result column="access" property="accessInt"/>
+        <result column="line_number" property="lineNumber"/>
     </resultMap>
     <insert id="insertMethod" parameterType="MethodEntity">
         INSERT INTO method_table
-        (method_name, method_desc, is_static, class_name, access)
+        (method_name, method_desc, is_static, class_name, access, line_number)
         VALUES
         <foreach collection="list" separator="," item="item">
-            (#{item.methodName}, #{item.methodDesc}, #{item.isStatic}, #{item.className}, #{item.access})
+            (#{item.methodName}, #{item.methodDesc}, #{item.isStatic}, #{item.className}, #{item.access}, #{item.lineNumber})
         </foreach>
     </insert>
     <select id="selectMethodsByClassName" resultMap="methodMap">


### PR DESCRIPTION
需求描述：
在使用 EL 表达式搜索时，搜索结果是可以根据类名排序的，但同一个类的方法是没有顺序的。点击搜索结果时一般会从上往下一个一个点，没有顺序的话代码显示会很混乱。例如点击第一个方法，可能会定位到类的最下方，但点击第二个方法又跳到中间，这样会给用户带来困扰。

<img width="611" alt="截屏2024-08-23 下午12 36 17" src="https://github.com/user-attachments/assets/33b6751a-c95d-4043-b069-c5454a838767">

实现：
在字节码扫描时把方法的行号保存到 method_table，搜索时根据这个行号排序。

遗留问题：
抽象方法和接口的方法没法获取到行号，如果一个类中有抽象方法，这个方法还是没法排序。这个在用户体验上应该问题不大，抽象方法（行号没有的话是-1）都会在列表的最前面。