### PR TITLE
代码逻辑整理

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/core/CoreRunner.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/CoreRunner.java
@@ -36,26 +36,19 @@ public class CoreRunner {
     public static void run(Path jarPath, Path rtJarPath, boolean fixClass) {
         // 2024-07-05 不允许太大的 JAR 文件
         long totalSize = 0;
+        List<String> beforeJarList = new ArrayList<>();
         if (Files.isDirectory(jarPath)) {
-            List<String> files = DirUtil.GetFiles(jarPath.toAbsolutePath().toString());
-            if (rtJarPath != null) {
-                files.add(rtJarPath.toAbsolutePath().toString());
-            }
-            for (String s : files) {
-                if (s.toLowerCase().endsWith(".jar") || s.toLowerCase().endsWith(".war")) {
-                    totalSize += Paths.get(s).toFile().length();
-                }
-            }
+            beforeJarList.addAll(DirUtil.GetFiles(jarPath.toAbsolutePath().toString()));
         } else {
-            List<String> jarList = new ArrayList<>();
-            if (rtJarPath != null) {
-                jarList.add(rtJarPath.toAbsolutePath().toString());
-            }
-            jarList.add(jarPath.toAbsolutePath().toString());
-            for (String s : jarList) {
-                if (s.toLowerCase().endsWith(".jar") || s.toLowerCase().endsWith(".war")) {
-                    totalSize += Paths.get(s).toFile().length();
-                }
+            beforeJarList.add(jarPath.toAbsolutePath().toString());
+
+        }
+        if (rtJarPath != null) {
+            beforeJarList.add(rtJarPath.toAbsolutePath().toString());
+        }
+        for (String s : beforeJarList) {
+            if (s.toLowerCase().endsWith(".jar") || s.toLowerCase().endsWith(".war")) {
+                totalSize += Paths.get(s).toFile().length();
             }
         }
 
@@ -123,13 +116,15 @@ public class CoreRunner {
         // BUG CLASS NAME
         for (ClassFileEntity cf : cfs) {
             String className = cf.getClassName();
-            int i = className.indexOf("classes");
-            if (className.contains("BOOT-INF")) {
-                className = className.substring(i + 8);
-            } else if (className.contains("WEB-INF")) {
-                className = className.substring(i + 7);
-            }
-            if (fixClass) {
+            if(fixClass == false){
+                int i = className.indexOf("classes");
+                if (className.contains("BOOT-INF")) {
+                    className = className.substring(i + 8);
+                } else if (className.contains("WEB-INF")) {
+                    className = className.substring(i + 7);
+                }
+                cf.setClassName(className);
+            }else{
                 // fix class name
                 Path parPath = Paths.get(Const.tempDir);
                 FixClassVisitor cv = new FixClassVisitor();
@@ -151,8 +146,6 @@ public class CoreRunner {
                 }
                 cf.setClassName(className);
                 cf.setPath(Paths.get(className));
-            } else {
-                cf.setClassName(className);
             }
         }
 

--- a/src/main/java/me/n1ar4/jar/analyzer/core/InheritanceRunner.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/InheritanceRunner.java
@@ -41,18 +41,19 @@ public class InheritanceRunner {
     public static Map<MethodReference.Handle, Set<MethodReference.Handle>> getAllMethodImplementations(
             InheritanceMap inheritanceMap, Map<MethodReference.Handle, MethodReference> methodMap) {
         Map<ClassReference.Handle, Set<MethodReference.Handle>> methodsByClass = getMethodsByClass(methodMap);
-        Map<ClassReference.Handle, Set<ClassReference.Handle>> subClassMap = new HashMap<>();
-        for (Map.Entry<ClassReference.Handle, Set<ClassReference.Handle>> entry : inheritanceMap.entrySet()) {
-            for (ClassReference.Handle parent : entry.getValue()) {
-                if (!subClassMap.containsKey(parent)) {
-                    Set<ClassReference.Handle> subClasses = new HashSet<>();
-                    subClasses.add(entry.getKey());
-                    subClassMap.put(parent, subClasses);
-                } else {
-                    subClassMap.get(parent).add(entry.getKey());
-                }
-            }
-        }
+//        Map<ClassReference.Handle, Set<ClassReference.Handle>> subClassMap = new HashMap<>();
+//        for (Map.Entry<ClassReference.Handle, Set<ClassReference.Handle>> entry : inheritanceMap.entrySet()) {
+//            for (ClassReference.Handle parent : entry.getValue()) {
+//                if (!subClassMap.containsKey(parent)) {
+//                    Set<ClassReference.Handle> subClasses = new HashSet<>();
+//                    subClasses.add(entry.getKey());
+//                    subClassMap.put(parent, subClasses);
+//                } else {
+//                    subClassMap.get(parent).add(entry.getKey());
+//                }
+//            }
+//        }
+        Map<ClassReference.Handle, Set<ClassReference.Handle>> subClassMap = inheritanceMap.getSubClassMap();
         Map<MethodReference.Handle, Set<MethodReference.Handle>> methodImplMap = new HashMap<>();
         for (MethodReference method : methodMap.values()) {
             if (method.isStatic()) {

--- a/src/main/java/me/n1ar4/jar/analyzer/core/asm/StringMethodVisitor.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/core/asm/StringMethodVisitor.java
@@ -16,6 +16,7 @@ public class StringMethodVisitor extends MethodVisitor {
     private final Map<ClassReference.Handle, ClassReference> classMap;
     private final Map<MethodReference.Handle, MethodReference> methodMap;
 
+    private MethodReference ownerHandle = null;
     public StringMethodVisitor(int api, MethodVisitor methodVisitor,
                                String owner, String methodName, String desc,
                                Map<MethodReference.Handle, List<String>> strMap,
@@ -28,6 +29,14 @@ public class StringMethodVisitor extends MethodVisitor {
         this.methodDesc = desc;
         this.classMap = classMap;
         this.methodMap = methodMap;
+
+        ClassReference.Handle ch = new ClassReference.Handle(ownerName);
+        if (classMap.get(ch) != null) {
+            MethodReference m = methodMap.get(new MethodReference.Handle(ch, methodName, methodDesc));
+            if (m != null) {
+                this.ownerHandle = m;
+            }
+        }
     }
 
     public static boolean isPrintable(String str) {
@@ -36,18 +45,20 @@ public class StringMethodVisitor extends MethodVisitor {
 
     @Override
     public void visitLdcInsn(Object o) {
+        if(this.ownerHandle == null)
+            return;
         if (o instanceof String) {
-            MethodReference mr = null;
-            ClassReference.Handle ch = new ClassReference.Handle(ownerName);
-            if (classMap.get(ch) != null) {
-                MethodReference m = methodMap.get(new MethodReference.Handle(ch, methodName, methodDesc));
-                if (m != null) {
-                    mr = m;
-                }
-            }
-            if (mr == null) {
-                return;
-            }
+//            MethodReference mr = null;
+//            ClassReference.Handle ch = new ClassReference.Handle(ownerName);
+//            if (classMap.get(ch) != null) {
+//                MethodReference m = methodMap.get(new MethodReference.Handle(ch, methodName, methodDesc));
+//                if (m != null) {
+//                    mr = m;
+//                }
+//            }
+//            if (mr == null) {
+//                return;
+//            }
             String str = (String) o;
             if (str.trim().isEmpty()) {
                 return;
@@ -55,9 +66,9 @@ public class StringMethodVisitor extends MethodVisitor {
             if (!isPrintable(str)) {
                 return;
             }
-            List<String> mList = strMap.getOrDefault(mr.getHandle(), new ArrayList<>());
+            List<String> mList = strMap.getOrDefault(this.ownerHandle.getHandle(), new ArrayList<>());
             mList.add(str);
-            strMap.put(mr.getHandle(), mList);
+            strMap.put(this.ownerHandle.getHandle(), mList);
         }
         super.visitLdcInsn(o);
     }

--- a/src/main/java/me/n1ar4/jar/analyzer/utils/JarUtil.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/utils/JarUtil.java
@@ -26,10 +26,11 @@ public class JarUtil {
     public static List<ClassFileEntity> resolveNormalJarFile(String jarPath) {
         try {
             Path tmpDir = Paths.get(Const.tempDir);
-            try {
-                Files.createDirectory(tmpDir);
-            } catch (Exception ignored) {
-            }
+//            try {
+//                Files.createDirectory(tmpDir);
+//            } catch (Exception ignored) {
+//            }
+            classFileSet.clear();
             resolve(jarPath, tmpDir);
             return new ArrayList<>(classFileSet);
         } catch (Exception e) {
@@ -145,7 +146,7 @@ public class JarUtil {
                     return;
                 }
             }
-            if (jarPathStr.toLowerCase(Locale.ROOT).endsWith(".jar") ||
+            else if (jarPathStr.toLowerCase(Locale.ROOT).endsWith(".jar") ||
                     jarPathStr.toLowerCase(Locale.ROOT).endsWith(".war")) {
                 InputStream is = Files.newInputStream(jarPath);
                 JarInputStream jarInputStream = new JarInputStream(is);


### PR DESCRIPTION
1. 收集 路径处代码有小部分代码重复
2. 收集类列表过程中重复删除
	1. 每一轮解析文件时都会尝试创建临时目录
	2.  .class 和 .jar .war 的判断用了多层 if , 按照逻辑，应该是 If else
	3. JarUtil.classFileSet 被重复使用，但是每次 AddAll 前没有清空，每轮 resolveNormalJarFile 中实际处理前 clear
3. 调整了 fixClass 判断逻辑 ， if - else 顺序
4. getAllMethodImplementations 中有重复生成 subClassMap 的情况，可以直接重用inheritanceMap中的 subClassMap
5. 获取字符串表时重复获取 MethodReference.Handle , 调整为在new StringMethodVisitor 时获取一次 MethodReference , 而不是每次访问常量时获取

(cherry picked from commit b3ff5335b2b7bdd9af5f7ed4cc9affc4a2c76291)