### PR TITLE
remote tomcat analyzer 远程连接初步修改

### DIFF
--- a/agent/package.sh
+++ b/agent/package.sh
@@ -1,0 +1,2 @@
+set MAVEN_OPTS="-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
+mvn -B clean package -DskipTests --file pom.xml

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -80,6 +80,7 @@
                         </manifest>
                         <manifestEntries>
                             <Agent-Class>com.n1ar4.agent.Agent</Agent-Class>
+                            <Premain-Class>com.n1ar4.agent.Agent</Premain-Class>
                             <Can-Retransform-Classes>true</Can-Retransform-Classes>
                             <Can-Redefine-Classes>true</Can-Redefine-Classes>
                         </manifestEntries>

--- a/agent/src/main/java/com/n1ar4/agent/Agent.java
+++ b/agent/src/main/java/com/n1ar4/agent/Agent.java
@@ -38,14 +38,15 @@ public class Agent {
     @SuppressWarnings("all")
     public static void agentmain(String agentArgs, Instrumentation ins) {
         if (agentArgs == null || agentArgs.trim().equals("")) {
-            return;
+            agentArgs = "12345678";
+            System.out.println("default password : " + agentArgs);
         }
         if (agentArgs.length() != 8) {
             return;
         }
         PASSWORD = agentArgs;
         staticIns = ins;
-        staticClasses = (Class<?>[]) ins.getAllLoadedClasses();
+
         new Thread(() -> {
             try {
                 int port = 10033;
@@ -62,6 +63,7 @@ public class Agent {
                 ServerSocket ss = new ServerSocket(port);
                 while (true) {
                     Socket socket = ss.accept();
+                    staticClasses = (Class<?>[]) ins.getAllLoadedClasses();
                     new Thread(new Task(socket)).start();
                 }
             } catch (Exception ex) {
@@ -69,4 +71,8 @@ public class Agent {
             }
         }).start();
     }
+    public static void premain(String agentArgs, final Instrumentation inst) {
+        agentmain(agentArgs, inst);
+    }
+
 }

--- a/src/main/java/me/n1ar4/shell/analyzer/form/ShellForm.java
+++ b/src/main/java/me/n1ar4/shell/analyzer/form/ShellForm.java
@@ -601,27 +601,27 @@ public class ShellForm {
     public static void start0() {
         // check windows
         // 目前该功能仅给 Windows 使用
-        if (!OSUtil.isWindows() || !Version.isJava8()) {
-            JOptionPane.showMessageDialog(MainForm.getInstance().getMasterPanel(),
-                    "<html>" +
-                            "only support jdk8/windows<br>" +
-                            "目前只支持 jdk8/windows 系统<br>" +
-                            "更多信息参考原始项目地址：<br>" +
-                            "https://github.com/4ra1n/shell-analyzer" +
-                            "</html>");
-            return;
-        }
+//        if (!OSUtil.isWindows() || !Version.isJava8()) {
+//            JOptionPane.showMessageDialog(MainForm.getInstance().getMasterPanel(),
+//                    "<html>" +
+//                            "only support jdk8/windows<br>" +
+//                            "目前只支持 jdk8/windows 系统<br>" +
+//                            "更多信息参考原始项目地址：<br>" +
+//                            "https://github.com/4ra1n/shell-analyzer" +
+//                            "</html>");
+//            return;
+//        }
 
-        // 检查端口 10033 端口是否被占用
-        if (SocketUtil.isPortInUse("localhost", 10033)) {
-            JOptionPane.showMessageDialog(MainForm.getInstance().getMasterPanel(),
-                    "<html>" +
-                            "10033 port in use<br>" +
-                            "10033 端口被占用<br>" +
-                            "该功能需要使用该端口" +
-                            "</html>");
-            return;
-        }
+//        // 检查端口 10033 端口是否被占用
+//        if (SocketUtil.isPortInUse("localhost", 10033)) {
+//            JOptionPane.showMessageDialog(MainForm.getInstance().getMasterPanel(),
+//                    "<html>" +
+//                            "10033 port in use<br>" +
+//                            "10033 端口被占用<br>" +
+//                            "该功能需要使用该端口" +
+//                            "</html>");
+//            return;
+//        }
 
         JFrame frame = new JFrame("tomcat-analyzer by 4ra1n");
         instance = new ShellForm();


### PR DESCRIPTION
- 注释 windows / jdk8 检测
- 注释 10033 端口占用检测
- 目前测试可以在 ubuntu 上完成对于 -javaagent 加载的 agent 的远程连接和 tomcat 分析
	- 需要点击开始分析 ，并且手动输入密码 12345678 , 这是目前没有设置 javaagent 参数时的默认密码 ， 会在目标进程运行时显示出来