### PR TITLE
【优化】修复高分辨率下缩放导致GUI显示不完整的BUG

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/gui/MainForm.form
+++ b/src/main/java/me/n1ar4/jar/analyzer/gui/MainForm.form
@@ -30,11 +30,7 @@
           </grid>
           <tabbedpane id="91706" binding="tabbedPanel">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="2" indent="0" use-parent-layout="false">
-                <minimum-size width="550" height="-1"/>
-                <preferred-size width="550" height="200"/>
-                <maximum-size width="550" height="-1"/>
-              </grid>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>

--- a/src/main/java/me/n1ar4/jar/analyzer/gui/MainForm.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/gui/MainForm.java
@@ -1222,7 +1222,7 @@ public class MainForm {
         corePanel.add(codePanel, new GridConstraints(0, 1, 3, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_WANT_GROW, new Dimension(700, 750), new Dimension(700, 750), null, 0, false));
         codePanel.setBorder(BorderFactory.createTitledBorder(null, "Java Decompile Code", TitledBorder.DEFAULT_JUSTIFICATION, TitledBorder.DEFAULT_POSITION, null, null));
         tabbedPanel = new JTabbedPane();
-        corePanel.add(tabbedPanel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_VERTICAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, new Dimension(550, -1), new Dimension(550, 200), new Dimension(550, -1), 0, false));
+        corePanel.add(tabbedPanel, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_VERTICAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, new Dimension(-1, -1), new Dimension(-1, -1), new Dimension(-1, -1), 0, false));
         startPanel = new JPanel();
         startPanel.setLayout(new GridLayoutManager(3, 1, new Insets(0, 0, 0, 0), -1, -1));
         tabbedPanel.addTab("start", startPanel);


### PR DESCRIPTION
测试多种分辨率缩放下显示无问题

![image](https://github.com/user-attachments/assets/90f7325c-aa92-48d6-b3cf-bfd801ca60d5)

![image](https://github.com/user-attachments/assets/a0f335ab-0c69-484f-9e2c-3cca0e2d9a99)

![image](https://github.com/user-attachments/assets/2db3a78c-64fa-405b-9108-4a4521b2c412)


