### PR TITLE
【修复】SpringMethodAdapter-RestFul规则空路径处理

### DIFF
--- a/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
+++ b/src/main/java/me/n1ar4/jar/analyzer/analyze/spring/asm/SpringMethodAdapter.java
@@ -10,6 +10,7 @@
 
 package me.n1ar4.jar.analyzer.analyze.spring.asm;
 
+import cn.hutool.core.util.StrUtil;
 import me.n1ar4.jar.analyzer.analyze.spring.SpringConstant;
 import me.n1ar4.jar.analyzer.analyze.spring.SpringController;
 import me.n1ar4.jar.analyzer.analyze.spring.SpringMapping;
@@ -136,7 +137,10 @@ public class SpringMethodAdapter extends MethodVisitor {
                 }
             });
             for (SpringMapping mapping : currentMapping.getController().getMappings()) {
-                if (mapping.getPath().endsWith("/")) {
+                if (StrUtil.isEmpty(mapping.getPath())) {
+                    mapping.setPath(null);
+                }
+                if (mapping.getPath()!=null&&mapping.getPath().endsWith("/")) {
                     mapping.setPath(mapping.getPath().substring(0, mapping.getPath().length() - 1));
                 }
             }


### PR DESCRIPTION
![微信截图_20250401101912](https://github.com/user-attachments/assets/7682f562-a523-421b-8115-0d87e0c9b624)
![微信截图_20250401105134](https://github.com/user-attachments/assets/3d11fdd3-aba6-4cbd-b790-2d2bbd9e35a5)
![微信截图_20250401105506](https://github.com/user-attachments/assets/e26f7a8e-655b-4b64-ad3e-269467980e01)
**使用RestFul规则的mapping不存在映射地址，为null时报错导致整个类及其以内的信息都报错导致无法存入数据库中**
解决#147 